### PR TITLE
Fix toltec package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Make sure to describe what I should be working on :)
 
 Easiest installation through [toltec's `opkg`](https://github.com/toltec-dev/toltec)
 ```
-opkg update && opkg install whiteboard_hypercard
+opkg update && opkg install whiteboard-hypercard
 ```
 
 ### Self-hosting whiteboard-server / hosting private rooms


### PR DESCRIPTION
Not sure if the package name changed, but in the latest version of toltec, there's a hyphen not an underscore.